### PR TITLE
remember last selected directory for extraction

### DIFF
--- a/src/RDAExplorerGUI/App.config
+++ b/src/RDAExplorerGUI/App.config
@@ -25,6 +25,12 @@
             <setting name="Window_IsMaximized" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="LastSelectedPathForExtraction" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="SettingsUpgradeNeeded" serializeAs="String">
+                <value>True</value>
+            </setting>
         </RDAExplorerGUI.Properties.Settings>
     </userSettings>
 </configuration>

--- a/src/RDAExplorerGUI/MainWindow.xaml.cs
+++ b/src/RDAExplorerGUI/MainWindow.xaml.cs
@@ -39,6 +39,13 @@ namespace RDAExplorerGUI
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             NewFile();
+
+            if (Settings.Default.SettingsUpgradeNeeded)
+            {
+                Settings.Default.Upgrade();
+                Settings.Default.SettingsUpgradeNeeded = false;
+                Settings.Default.Save();
+            }
         }
 
         private void MainWindow_Closing(object sender, CancelEventArgs e)
@@ -125,7 +132,8 @@ namespace RDAExplorerGUI
                 foreach (RDASkippedDataSection skippedBlock in CurrentReader.SkippedDataSections)
                 {
                     string title = skippedBlock.blockInfo.fileCount + " encrypted files";
-                    treeView.Items.Add(new RDASkippedDataSectionTreeViewItem() {
+                    treeView.Items.Add(new RDASkippedDataSectionTreeViewItem()
+                    {
                         Section = skippedBlock,
                         Header = ControlExtension.BuildImageTextblock("pack://application:,,,/Images/Icons/error.png", title)
                     });
@@ -333,8 +341,12 @@ namespace RDAExplorerGUI
         private void archive_ExtractAll_Click(object sender, RoutedEventArgs e)
         {
             FolderBrowserDialog dlg = new FolderBrowserDialog();
+            dlg.SelectedPath = Settings.Default.LastSelectedPathForExtraction;
             if (dlg.ShowDialog() != System.Windows.Forms.DialogResult.OK)
                 return;
+
+            Settings.Default.LastSelectedPathForExtraction = dlg.SelectedPath;//settings are saved when window is closing
+
             BackgroundWorker wrk = new BackgroundWorker();
             wrk.WorkerReportsProgress = true;
             progressBar_Status.Visibility = Visibility.Visible;
@@ -366,8 +378,12 @@ namespace RDAExplorerGUI
         private void archive_ExtractSelected_Click(object sender, RoutedEventArgs e)
         {
             FolderBrowserDialog dlg = new FolderBrowserDialog();
+            dlg.SelectedPath = Settings.Default.LastSelectedPathForExtraction;
             if (dlg.ShowDialog() != System.Windows.Forms.DialogResult.OK)
                 return;
+
+            Settings.Default.LastSelectedPathForExtraction = dlg.SelectedPath;//settings are saved when window is closing
+
             BackgroundWorker wrk = new BackgroundWorker();
             wrk.WorkerReportsProgress = true;
             progressBar_Status.Visibility = Visibility.Visible;

--- a/src/RDAExplorerGUI/Properties/Settings.Designer.cs
+++ b/src/RDAExplorerGUI/Properties/Settings.Designer.cs
@@ -82,5 +82,29 @@ namespace RDAExplorerGUI.Properties {
                 this["Window_IsMaximized"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastSelectedPathForExtraction {
+            get {
+                return ((string)(this["LastSelectedPathForExtraction"]));
+            }
+            set {
+                this["LastSelectedPathForExtraction"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool SettingsUpgradeNeeded {
+            get {
+                return ((bool)(this["SettingsUpgradeNeeded"]));
+            }
+            set {
+                this["SettingsUpgradeNeeded"] = value;
+            }
+        }
     }
 }

--- a/src/RDAExplorerGUI/Properties/Settings.settings
+++ b/src/RDAExplorerGUI/Properties/Settings.settings
@@ -17,5 +17,11 @@
     <Setting Name="Window_IsMaximized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="LastSelectedPathForExtraction" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="SettingsUpgradeNeeded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
This PR adds functionality to remember the last selected directory for extraction.
This will make it a bit easier when extracting multiple files.