### PR TITLE
remove AnnoModificationManager4 reference from RDAExplorer

### DIFF
--- a/src/RDAExplorer/RDAExplorer.csproj
+++ b/src/RDAExplorer/RDAExplorer.csproj
@@ -56,11 +56,5 @@
     <Compile Include="ZLib\ZLib.cs" />
     <Compile Include="AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\AnnoModificationManager4\AnnoModificationManager4.csproj">
-      <Project>{579d60f0-65bd-4577-b3d2-a9c80b7d9baa}</Project>
-      <Name>AnnoModificationManager4</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/RDAExplorer/RDAFolder.cs
+++ b/src/RDAExplorer/RDAFolder.cs
@@ -1,4 +1,4 @@
-﻿using AnnoModificationManager4.Misc;
+﻿
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -114,7 +114,8 @@ namespace RDAExplorer
             if (list.Count == 1)
                 return root1;
             list.RemoveAt(0);
-            return NavigateTo(root1, StringExtension.PutTogether(list, '/'), CurrentPos + "/" + str);
+
+            return NavigateTo(root1, string.Join("/", list), CurrentPos + "/" + str);
         }
     }
 }


### PR DESCRIPTION
The only call (StringExtensions.PutTogether) can be replaced with string.Join.
By removing the reference, RDAExplorer is free of WinForms dependencies.